### PR TITLE
Add tabbed UI with operation, status, settings

### DIFF
--- a/led-commom/app/build.gradle
+++ b/led-commom/app/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation "com.google.android.material:material:1.4.0"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/led-commom/app/src/main/java/com/yjsoft/led/MainActivity.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/MainActivity.kt
@@ -1,37 +1,50 @@
 package com.yjsoft.led
 
-import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.yjsoft.core.YJDeviceManager
-import com.yjsoft.led.ui.BleActivity
-import com.yjsoft.led.ui.WifiActivity
+import com.yjsoft.led.ui.fragment.OperationFragment
+import com.yjsoft.led.ui.fragment.SettingsFragment
+import com.yjsoft.led.ui.fragment.StatusFragment
 import com.yjsoft.led.util.FileUtils
 import kotlinx.android.synthetic.main.activity_main.*
 import java.io.File
 
-class MainActivity : AppCompatActivity(){
+class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-
-        val file = File(externalCacheDir?.absolutePath.plus("/Led/.font/"))
-        Log.e("------路径：",file.absolutePath)
-        if (!file.exists()){
-            file.mkdirs()
-            FileUtils.copyAssetsFiles(this,"font",file.absolutePath)
-        }
-
+        initFontDir()
         YJDeviceManager.instance.init(this.application)
 
-        tv_wifi.setOnClickListener {
-            startActivity(Intent(this, WifiActivity::class.java))
+        bottom_navigation.setOnNavigationItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.navigation_operation -> switchFragment(OperationFragment())
+                R.id.navigation_status -> switchFragment(StatusFragment())
+                R.id.navigation_settings -> switchFragment(SettingsFragment())
+            }
+            true
         }
 
-        tv_ble.setOnClickListener {
-            startActivity(Intent(this, BleActivity::class.java))
+        bottom_navigation.selectedItemId = R.id.navigation_operation
+    }
+
+    private fun switchFragment(fragment: Fragment) {
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, fragment)
+            .commit()
+    }
+
+    private fun initFontDir() {
+        val file = File(externalCacheDir?.absolutePath.plus("/Led/.font/"))
+        Log.e("------路径：", file.absolutePath)
+        if (!file.exists()) {
+            file.mkdirs()
+            FileUtils.copyAssetsFiles(this, "font", file.absolutePath)
         }
     }
 }

--- a/led-commom/app/src/main/java/com/yjsoft/led/ui/fragment/OperationFragment.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/ui/fragment/OperationFragment.kt
@@ -1,0 +1,32 @@
+package com.yjsoft.led.ui.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import com.yjsoft.led.R
+import kotlinx.android.synthetic.main.fragment_operation.*
+
+class OperationFragment : Fragment() {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_operation, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        btn_text1.setOnClickListener { showToast("text1") }
+        btn_text2.setOnClickListener { showToast("text2") }
+        btn_text3.setOnClickListener { showToast("text3") }
+        btn_text4.setOnClickListener { showToast("text4") }
+        btn_image1.setOnClickListener { showToast("image1") }
+        btn_image2.setOnClickListener { showToast("image2") }
+        btn_image3.setOnClickListener { showToast("image3") }
+        btn_image4.setOnClickListener { showToast("image4") }
+    }
+
+    private fun showToast(text: String) {
+        Toast.makeText(requireContext(), text, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/led-commom/app/src/main/java/com/yjsoft/led/ui/fragment/SettingsFragment.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/ui/fragment/SettingsFragment.kt
@@ -1,0 +1,28 @@
+package com.yjsoft.led.ui.fragment
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.yjsoft.led.R
+import com.yjsoft.led.ui.BleActivity
+import com.yjsoft.led.ui.WifiActivity
+import kotlinx.android.synthetic.main.fragment_settings.*
+
+class SettingsFragment : Fragment() {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_settings, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        tv_wifi.setOnClickListener {
+            startActivity(Intent(requireContext(), WifiActivity::class.java))
+        }
+        tv_ble.setOnClickListener {
+            startActivity(Intent(requireContext(), BleActivity::class.java))
+        }
+    }
+}

--- a/led-commom/app/src/main/java/com/yjsoft/led/ui/fragment/StatusFragment.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/ui/fragment/StatusFragment.kt
@@ -1,0 +1,40 @@
+package com.yjsoft.led.ui.fragment
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.yjsoft.led.R
+import kotlinx.android.synthetic.main.fragment_status.*
+
+class StatusFragment : Fragment() {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_status, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        updateStatus()
+    }
+
+    private fun updateStatus() {
+        tv_wifi_status.text = getConnectionStatus(NetworkCapabilities.TRANSPORT_WIFI)
+        tv_bluetooth_status.text = getString(R.string.status_unknown)
+        tv_led_status.text = getString(R.string.status_unknown)
+    }
+
+    private fun getConnectionStatus(transport: Int): String {
+        val cm = context?.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val network = cm.activeNetwork ?: return getString(R.string.status_disconnected)
+        val caps = cm.getNetworkCapabilities(network) ?: return getString(R.string.status_disconnected)
+        return if (caps.hasTransport(transport)) {
+            getString(R.string.status_connected)
+        } else {
+            getString(R.string.status_disconnected)
+        }
+    }
+}

--- a/led-commom/app/src/main/res/layout/activity_main.xml
+++ b/led-commom/app/src/main/res/layout/activity_main.xml
@@ -1,23 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="horizontal"
-    tools:context=".MainActivity">
+    android:orientation="vertical">
 
-    <Button
-        android:id="@+id/tv_wifi"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="WiFi 设备"
-        tools:ignore="MissingConstraints" />
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 
-    <Button
-        android:id="@+id/tv_ble"
-        android:layout_width="wrap_content"
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_navigation"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="蓝牙 设备"
-        tools:ignore="MissingConstraints" />
+        app:menu="@menu/bottom_nav_menu" />
 </LinearLayout>

--- a/led-commom/app/src/main/res/layout/fragment_operation.xml
+++ b/led-commom/app/src/main/res/layout/fragment_operation.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <ImageView
+        android:id="@+id/previewImage"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:background="@android:color/darker_gray" />
+
+    <GridLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:columnCount="4"
+        android:padding="8dp">
+        <Button android:id="@+id/btn_text1" android:text="text1" />
+        <Button android:id="@+id/btn_text2" android:text="text2" />
+        <Button android:id="@+id/btn_text3" android:text="text3" />
+        <Button android:id="@+id/btn_text4" android:text="text4" />
+        <Button android:id="@+id/btn_image1" android:text="image1" />
+        <Button android:id="@+id/btn_image2" android:text="image2" />
+        <Button android:id="@+id/btn_image3" android:text="image3" />
+        <Button android:id="@+id/btn_image4" android:text="image4" />
+    </GridLayout>
+</LinearLayout>

--- a/led-commom/app/src/main/res/layout/fragment_settings.xml
+++ b/led-commom/app/src/main/res/layout/fragment_settings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    tools:context=".MainActivity">
+
+    <Button
+        android:id="@+id/tv_wifi"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="WiFi 设备"
+        tools:ignore="MissingConstraints" />
+
+    <Button
+        android:id="@+id/tv_ble"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="蓝牙 设备"
+        tools:ignore="MissingConstraints" />
+</LinearLayout>

--- a/led-commom/app/src/main/res/layout/fragment_status.xml
+++ b/led-commom/app/src/main/res/layout/fragment_status.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="WiFi:" />
+    <TextView
+        android:id="@+id/tv_wifi_status"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingBottom="8dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Bluetooth:" />
+    <TextView
+        android:id="@+id/tv_bluetooth_status"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingBottom="8dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="LED:" />
+    <TextView
+        android:id="@+id/tv_led_status"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/led-commom/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/led-commom/app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/navigation_operation"
+        android:icon="@android:drawable/ic_menu_edit"
+        android:title="@string/tab_operation" />
+    <item
+        android:id="@+id/navigation_status"
+        android:icon="@android:drawable/ic_menu_info_details"
+        android:title="@string/tab_status" />
+    <item
+        android:id="@+id/navigation_settings"
+        android:icon="@android:drawable/ic_menu_preferences"
+        android:title="@string/tab_settings" />
+</menu>

--- a/led-commom/app/src/main/res/values/strings.xml
+++ b/led-commom/app/src/main/res/values/strings.xml
@@ -3,5 +3,11 @@
     <string name="wifi">WIFI</string>
     <string name="bluetooth">Bluetooth</string>
     <string name="bluetooth_list">Bluetooth Device List</string>
+    <string name="tab_operation">조작</string>
+    <string name="tab_status">상태</string>
+    <string name="tab_settings">설정</string>
+    <string name="status_connected">Connected</string>
+    <string name="status_disconnected">Disconnected</string>
+    <string name="status_unknown">Unknown</string>
     <style name="world_text">"{\"id_dev\":\"620312017C\",\"pkts_program\":{\"id_pro\":1,\"list_region\":[{\"info_pos\":{\"h\":64,\"w\":64,\"x\":0,\"y\":0},\"list_item\":[{\"align_horizontal\":\"left\",\"align_vertical\":\"top\",\"color\":255,\"data_save\":0,\"font\":\"/storage/emulated/0/Android/data/com.yj.led/cache/LED/.font/黑体.ttf\",\"info_animate\":{\"model_normal\":1,\"speed\":10,\"time_stay\":3},\"info_border\":{\"fixed_value\":0,\"type\":\"fixed\"},\"rotate\":0,\"size\":16,\"text\":\"测试文字\",\"type_item\":\"text_pic\"}]}],\"property_pro\":{\"gray\":4,\"height\":64,\"send_gif_src\":1,\"type_bg\":0,\"type_color\":3,\"type_pro\":0,\"width\":64}},\"sno\":\"4294901763\"}"</style>
 </resources>


### PR DESCRIPTION
## Summary
- introduce bottom navigation in `MainActivity`
- implement `Operation`, `Status`, and `Settings` fragments
- move existing WiFi/BLE buttons to `SettingsFragment`
- add layouts and menu resources for new UI
- include Material Components dependency

## Testing
- `gradlew test` *(fails: /usr/bin/env: ‘sh\r’: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685a5a80e9ec83298a31ce79b4f298ff