### PR TITLE
Update AGP to v8.1 and set SDK 33

### DIFF
--- a/led-commom/app/build.gradle
+++ b/led-commom/app/build.gradle
@@ -5,12 +5,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.1"
+    compileSdkVersion 33
+    buildToolsVersion "33.0.0"
     defaultConfig {
         applicationId "com.yjsoft.led"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 2
         versionName "1.0.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/led-commom/build.gradle
+++ b/led-commom/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.8.10'
     repositories {
         google()
         jcenter()
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Summary
- bump Android Gradle Plugin to 8.1.0
- use Kotlin 1.8.10
- set compile/target SDK to 33

## Testing
- `./gradlew --version` *(fails: HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685aa2523f748329940e39c511127d62