### PR TITLE
Fix build issues in manifest and strings

### DIFF
--- a/led-commom/app/src/main/AndroidManifest.xml
+++ b/led-commom/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.yjsoft.led">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -18,7 +17,8 @@
         <activity android:name=".ui.ScanBleActivity"></activity>
         <activity android:name=".ui.BleActivity" />
         <activity android:name=".ui.WifiActivity" />
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/led-commom/app/src/main/res/values/strings.xml
+++ b/led-commom/app/src/main/res/values/strings.xml
@@ -12,6 +12,4 @@
     <string name="status_connected">Connected</string>
     <string name="status_disconnected">Disconnected</string>
     <string name="status_unknown">Unknown</string>
-    <style name="world_text">"{\"id_dev\":\"620312017C\",\"pkts_program\":{\"id_pro\":1,\"list_region\":[{\"info_pos\":{\"h\":64,\"w\":64,\"x\":0,\"y\":0},\"list_item\":[{\"align_horizontal\":\"left\",\"align_vertical\":\"top\",\"color\":255,\"data_save\":0,\"font\":\"/storage/emulated/0/Android/data/com.yj.led/cache/LED/.font/黑体.ttf\",\"info_animate\":{\"model_normal\":1,\"speed\":10,\"time_stay\":3},\"info_border\":{\"fixed_value\":0,\"type\":\"fixed\"},\"rotate\":0,\"size\":16,\"text\":\"测试文字\",\"type_item\":\"text_pic\"}]}],\"property_pro\":{\"gray\":4,\"height\":64,\"send_gif_src\":1,\"type_bg\":0,\"type_color\":3,\"type_pro\":0,\"width\":64}},\"sno\":\"4294901763\"}"</style>
-
 </resources>


### PR DESCRIPTION
## Summary
- remove duplicate `world_text` style from strings to avoid resource merge conflict
- drop obsolete `package` attribute in `AndroidManifest.xml`
- mark `MainActivity` as `android:exported="true"`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685aabf2d3d483299dfa2925b089e93c