### PR TITLE
Fix crash on Android 12+ by requesting new Bluetooth permissions

### DIFF
--- a/led-commom/app/src/main/AndroidManifest.xml
+++ b/led-commom/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
 
     <application
         android:allowBackup="true"

--- a/led-commom/app/src/main/java/com/yjsoft/led/ui/ScanBleActivity.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/ui/ScanBleActivity.kt
@@ -70,18 +70,23 @@ class ScanBleActivity : AppCompatActivity(), YJCallBack {
     }
 
     private fun checkPermission() {
-        val permissions = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
+        val permissions = mutableListOf(Manifest.permission.ACCESS_FINE_LOCATION)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            permissions.add(Manifest.permission.BLUETOOTH_SCAN)
+            permissions.add(Manifest.permission.BLUETOOTH_CONNECT)
+        }
+
         val permissionDeniedList = ArrayList<String>()
         for (permission in permissions) {
             val permissionCheck = ContextCompat.checkSelfPermission(this, permission)
-            if (permissionCheck == PackageManager.PERMISSION_GRANTED) {
-//                onPermissionGranted(permission)
-                YJDeviceManager.instance.scan()
-            } else {
+            if (permissionCheck != PackageManager.PERMISSION_GRANTED) {
                 permissionDeniedList.add(permission)
             }
         }
-        if (permissionDeniedList.isNotEmpty()) {
+
+        if (permissionDeniedList.isEmpty()) {
+            YJDeviceManager.instance.scan()
+        } else {
             val deniedPermissions = permissionDeniedList.toTypedArray()
             ActivityCompat.requestPermissions(
                 this,


### PR DESCRIPTION
## Summary
- add `BLUETOOTH_CONNECT` and `BLUETOOTH_SCAN` permissions
- request Bluetooth permissions at runtime before initializing `YJDeviceManager`
- update BLE scan permission checks

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ab84c8c648329a2436585af6e28ed