### PR TITLE
Update operation fragment to hide text buttons

### DIFF
--- a/led-commom/app/src/main/java/com/yjsoft/led/ui/fragment/OperationFragment.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/ui/fragment/OperationFragment.kt
@@ -24,25 +24,16 @@ class OperationFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val t1 = getString(R.string.text_slot1)
-        val t2 = getString(R.string.text_slot2)
-        val t3 = getString(R.string.text_slot3)
-        val t4 = getString(R.string.text_slot4)
-
-        binding.btnText1.text = t1
-        binding.btnText2.text = t2
-        binding.btnText3.text = t3
-        binding.btnText4.text = t4
-
-        binding.btnText1.setOnClickListener { sendText(t1) }
-        binding.btnText2.setOnClickListener { sendText(t2) }
-        binding.btnText3.setOnClickListener { sendText(t3) }
-        binding.btnText4.setOnClickListener { sendText(t4) }
+        // Default text buttons are hidden for now
 
         binding.btnImage1.setOnClickListener { sendImage("images/img1.jpg") }
         binding.btnImage2.setOnClickListener { sendImage("images/img2.jpg") }
         binding.btnImage3.setOnClickListener { sendImage("images/img3.jpg") }
         binding.btnImage4.setOnClickListener { sendImage("images/img4.jpg") }
+        binding.btnImage5.setOnClickListener { sendImage("images/img5.jpg") }
+        binding.btnImage6.setOnClickListener { sendImage("images/img6.jpg") }
+        binding.btnImage7.setOnClickListener { sendImage("images/img7.jpg") }
+        binding.btnImage8.setOnClickListener { sendImage("images/img8.jpg") }
     }
 
     override fun onDestroyView() {

--- a/led-commom/app/src/main/res/layout/fragment_operation.xml
+++ b/led-commom/app/src/main/res/layout/fragment_operation.xml
@@ -16,13 +16,27 @@
         android:layout_height="wrap_content"
         android:columnCount="4"
         android:padding="8dp">
-        <Button android:id="@+id/btn_text1" android:text="@string/text_slot1" />
-        <Button android:id="@+id/btn_text2" android:text="@string/text_slot2" />
-        <Button android:id="@+id/btn_text3" android:text="@string/text_slot3" />
-        <Button android:id="@+id/btn_text4" android:text="@string/text_slot4" />
+        <!--
+        <Button
+            android:id="@+id/btn_text1"
+            android:text="@string/text_slot1" />
+        <Button
+            android:id="@+id/btn_text2"
+            android:text="@string/text_slot2" />
+        <Button
+            android:id="@+id/btn_text3"
+            android:text="@string/text_slot3" />
+        <Button
+            android:id="@+id/btn_text4"
+            android:text="@string/text_slot4" />
+        -->
         <Button android:id="@+id/btn_image1" android:text="image1" />
         <Button android:id="@+id/btn_image2" android:text="image2" />
         <Button android:id="@+id/btn_image3" android:text="image3" />
         <Button android:id="@+id/btn_image4" android:text="image4" />
+        <Button android:id="@+id/btn_image5" android:text="image5" />
+        <Button android:id="@+id/btn_image6" android:text="image6" />
+        <Button android:id="@+id/btn_image7" android:text="image7" />
+        <Button android:id="@+id/btn_image8" android:text="image8" />
     </GridLayout>
 </LinearLayout>


### PR DESCRIPTION
## Summary
- hide existing text buttons in `fragment_operation.xml`
- expand image button set to eight slots
- update `OperationFragment` to handle the additional image buttons

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685b9b78d1a48329abc5686883927873