### PR TITLE
Add BLE toolbar action

### DIFF
--- a/led-commom/app/src/main/java/com/yjsoft/led/MainActivity.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/MainActivity.kt
@@ -5,6 +5,10 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import android.view.Menu
+import android.view.MenuItem
+import android.content.Intent
+import com.yjsoft.led.ui.ScanBleActivity
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -27,6 +31,8 @@ class MainActivity : AppCompatActivity() {
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        setSupportActionBar(binding.toolbar)
+
         initFontDir()
         checkPermission()
 
@@ -40,6 +46,20 @@ class MainActivity : AppCompatActivity() {
         }
 
         binding.bottomNavigation.selectedItemId = R.id.navigation_operation
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.menu_main, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return if (item.itemId == R.id.action_ble) {
+            startActivity(Intent(this, ScanBleActivity::class.java))
+            true
+        } else {
+            super.onOptionsItemSelected(item)
+        }
     }
 
     private fun switchFragment(fragment: Fragment) {

--- a/led-commom/app/src/main/res/layout/activity_main.xml
+++ b/led-commom/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,11 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
     <FrameLayout
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"

--- a/led-commom/app/src/main/res/menu/menu_main.xml
+++ b/led-commom/app/src/main/res/menu/menu_main.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_ble"
+        android:icon="@android:drawable/stat_sys_data_bluetooth"
+        android:title="@string/bluetooth"
+        app:showAsAction="ifRoom" />
+</menu>


### PR DESCRIPTION
## Summary
- insert toolbar in `activity_main` layout
- add menu resource with Bluetooth action
- hook up toolbar in `MainActivity`
- start `ScanBleActivity` from the toolbar menu

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685b9e9dafa08329958af96c7a4a4bff