### PR TITLE
Add BLE scan toolbar menu

### DIFF
--- a/led-commom/app/src/main/java/com/yjsoft/led/MainActivity.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/MainActivity.kt
@@ -6,6 +6,8 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
+import android.view.Menu
+import android.view.MenuItem
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
@@ -17,6 +19,7 @@ import android.content.Context.MODE_PRIVATE
 import com.yjsoft.led.ui.fragment.OperationFragment
 import com.yjsoft.led.ui.fragment.SettingsFragment
 import com.yjsoft.led.ui.fragment.StatusFragment
+import com.yjsoft.led.ui.BleScanDialogFragment
 import com.yjsoft.led.util.FileUtils
 import com.yjsoft.led.databinding.ActivityMainBinding
 import java.io.File
@@ -30,6 +33,7 @@ class MainActivity : AppCompatActivity(), YJCallBack {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        setSupportActionBar(binding.toolbar)
 
         val prefs = getSharedPreferences("ble_device", MODE_PRIVATE)
         savedMac = prefs.getString("mac", null)
@@ -99,6 +103,21 @@ class MainActivity : AppCompatActivity(), YJCallBack {
         if (savedMac != null) {
             YJDeviceManager.instance.setCallBack(this)
             YJDeviceManager.instance.scan()
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.menu_main, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.action_ble -> {
+                BleScanDialogFragment().show(supportFragmentManager, "bleScan")
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
         }
     }
 

--- a/led-commom/app/src/main/res/layout/activity_main.xml
+++ b/led-commom/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,13 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+
     <FrameLayout
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"

--- a/led-commom/app/src/main/res/menu/menu_main.xml
+++ b/led-commom/app/src/main/res/menu/menu_main.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_ble"
+        android:icon="@android:drawable/stat_sys_data_bluetooth"
+        android:title="Bluetooth"
+        android:showAsAction="always"/>
+</menu>


### PR DESCRIPTION
## Summary
- add toolbar to `activity_main.xml`
- add Bluetooth action menu
- hook up toolbar in `MainActivity`
- open `BleScanDialogFragment` from the toolbar menu

## Testing
- `./gradlew --version` *(fails: unable to download gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685bad951aa88329aa07f75fa5a3c49e