### PR TITLE
Improve permission handling in MainActivity

### DIFF
--- a/led-commom/app/src/main/java/com/yjsoft/led/MainActivity.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/MainActivity.kt
@@ -16,6 +16,10 @@ import com.yjsoft.core.YJDeviceManager
 import com.yjsoft.core.bean.YJBleDevice
 import com.yjsoft.core.controler.YJCallBack
 import android.content.Context.MODE_PRIVATE
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.appcompat.app.AlertDialog
 import com.yjsoft.led.ui.fragment.OperationFragment
 import com.yjsoft.led.ui.fragment.SettingsFragment
 import com.yjsoft.led.ui.fragment.StatusFragment
@@ -85,9 +89,28 @@ class MainActivity : AppCompatActivity(), YJCallBack {
                 YJDeviceManager.instance.init(this.application)
                 checkAutoConnect()
             } else {
-                finish()
+                showPermissionExplanation()
             }
         }
+    }
+
+    private fun showPermissionExplanation() {
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.permission_required_title))
+            .setMessage(getString(R.string.permission_required_message))
+            .setCancelable(false)
+            .setPositiveButton(getString(R.string.action_open_settings)) { _, _ ->
+                val intent = Intent(
+                    Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                    Uri.fromParts("package", packageName, null)
+                )
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                startActivity(intent)
+            }
+            .setNegativeButton(getString(R.string.action_retry)) { _, _ ->
+                checkPermission()
+            }
+            .show()
     }
 
     private fun initFontDir() {

--- a/led-commom/app/src/main/res/values/strings.xml
+++ b/led-commom/app/src/main/res/values/strings.xml
@@ -18,4 +18,8 @@
     <string name="status_connected">Connected</string>
     <string name="status_disconnected">Disconnected</string>
     <string name="status_unknown">Unknown</string>
+    <string name="permission_required_title">Permissions Required</string>
+    <string name="permission_required_message">Bluetooth and location permissions are required for scanning devices. Please grant them in settings or retry.</string>
+    <string name="action_open_settings">Open Settings</string>
+    <string name="action_retry">Retry</string>
 </resources>


### PR DESCRIPTION
## Summary
- add dialog-based permission rationale
- provide options to open app settings or retry permission check
- add user-facing strings for permission rationale dialog

## Testing
- `./gradlew_unix test` *(fails: unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685bba65f858832984e14c4b50b487b9