### PR TITLE
Update permission logic and disable backup restore

### DIFF
--- a/led-commom/app/src/main/AndroidManifest.xml
+++ b/led-commom/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/led-commom/app/src/main/java/com/yjsoft/led/MainActivity.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/MainActivity.kt
@@ -70,16 +70,7 @@ class MainActivity : AppCompatActivity(), YJCallBack {
             permissions.add(Manifest.permission.BLUETOOTH_CONNECT)
         }
 
-        val denied = permissions.filter {
-            ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
-        }
-
-        if (denied.isEmpty()) {
-            YJDeviceManager.instance.init(this.application)
-            checkAutoConnect()
-        } else {
-            ActivityCompat.requestPermissions(this, denied.toTypedArray(), requestCode)
-        }
+        ActivityCompat.requestPermissions(this, permissions.toTypedArray(), requestCode)
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {


### PR DESCRIPTION
## Summary
- disable auto-restoration of app data so permissions prompt after reinstall
- request Bluetooth and location permissions on every launch

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685bbe2626748329b09da30b6b611a8b