### PR TITLE
Document supported ABIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# LED Project
+
+This project uses a local AAR dependency (`core-release.aar`).
+The AAR only contains native libraries for `arm64-v8a` and `armeabi-v7a`.
+Devices or emulators running on x86 or x86_64 architectures will fail to load
+the native libraries and the app will exit immediately.
+
+To run the app successfully:
+
+1. Use a physical device with an ARM-based CPU, **or**
+2. Obtain a version of `core-release.aar` that includes `x86` and `x86_64` native
+   libraries.
+
+The `app` module is configured to limit supported ABIs to the ones included in
+`core-release.aar`.

--- a/led-commom/app/build.gradle
+++ b/led-commom/app/build.gradle
@@ -14,6 +14,10 @@ android {
         versionCode 2
         versionName "1.0.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        // Limit supported ABIs to the ones provided in core-release.aar
+        ndk {
+            abiFilters "arm64-v8a", "armeabi-v7a"
+        }
     }
     buildTypes {
         release {


### PR DESCRIPTION
## Summary
- limit the supported ABIs to arm64-v8a and armeabi-v7a
- add a README that explains the missing x86 native libraries

## Testing
- `./gradlew --version` *(fails: unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685bc941f04883299575ce9909514006