### PR TITLE
Fix permission check regression

### DIFF
--- a/led-commom/app/src/main/java/com/yjsoft/led/MainActivity.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/MainActivity.kt
@@ -70,7 +70,16 @@ class MainActivity : AppCompatActivity(), YJCallBack {
             permissions.add(Manifest.permission.BLUETOOTH_CONNECT)
         }
 
-        ActivityCompat.requestPermissions(this, permissions.toTypedArray(), requestCode)
+        val denied = permissions.filter {
+            ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
+        }
+
+        if (denied.isEmpty()) {
+            YJDeviceManager.instance.init(this.application)
+            checkAutoConnect()
+        } else {
+            ActivityCompat.requestPermissions(this, denied.toTypedArray(), requestCode)
+        }
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {


### PR DESCRIPTION
## Summary
- restore original permission checking logic that only requests missing permissions

## Testing
- `gradle test` *(fails: Could not GET https://jcenter.bintray.com/org/jetbrains/kotlin/kotlin-gradle-plugin/1.8.10/kotlin-gradle-plugin-1.8.10.pom. Received status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_685bcbc232a48329a3b3a3c0ee4a5610