### PR TITLE
Fix toolbar crash by removing default action bar

### DIFF
--- a/led-commom/app/src/main/res/values/styles.xml
+++ b/led-commom/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>


### PR DESCRIPTION
## Summary
- switch `AppTheme` to `Theme.AppCompat.Light.NoActionBar`

This prevents the crash shown when `setSupportActionBar()` is called with a `MaterialToolbar`.

## Testing
- `gradlew test` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685bd045a8608329a9b47e0e7169fc6d