### PR TITLE
Add configurable start message for LED

### DIFF
--- a/led-commom/app/src/main/java/com/yjsoft/led/ui/BleActivity.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/ui/BleActivity.kt
@@ -93,7 +93,7 @@ class BleActivity : AppCompatActivity(), YJCallBack {
                         }else startActivity(Intent(this@BleActivity,ScanBleActivity::class.java))
                     }
 
-                    5 -> { showProgress(typeList[position]); YJDeviceManager.instance.sendShowCommon(ShowCmdUtil.text) }
+                    5 -> { showProgress(typeList[position]); YJDeviceManager.instance.sendShowCommon(ShowCmdUtil.startText(this@BleActivity)) }
                     6 -> { showProgress(typeList[position]); YJDeviceManager.instance.sendShowCommon(ShowCmdUtil.one_text) }
                     7 -> { showProgress(typeList[position]); YJDeviceManager.instance.sendShowCommon(ShowCmdUtil.two_text) }
                     8 -> { showProgress(typeList[position]); YJDeviceManager.instance.sendShowCommon(ShowCmdUtil.line_text) }

--- a/led-commom/app/src/main/java/com/yjsoft/led/ui/WifiActivity.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/ui/WifiActivity.kt
@@ -97,7 +97,7 @@ class WifiActivity : AppCompatActivity(), YJCallBack {
             override fun OnClickListener(position: Int) {
                 binding.tvResult.text = ""
                 when (typeList[position].position) {
-                    6 -> { showProgress(typeList[position].name ?: ""); YJDeviceManager.instance.sendShowCommon(ShowCmdUtil.text) }
+                    6 -> { showProgress(typeList[position].name ?: ""); YJDeviceManager.instance.sendShowCommon(ShowCmdUtil.startText(this@WifiActivity)) }
                     7 -> { showProgress(typeList[position].name ?: ""); YJDeviceManager.instance.sendShowCommon(ShowCmdUtil.one_text) }
                     8 -> { showProgress(typeList[position].name ?: ""); YJDeviceManager.instance.sendShowCommon(ShowCmdUtil.two_text) }
                     9 -> { showProgress(typeList[position].name ?: ""); YJDeviceManager.instance.sendShowCommon(ShowCmdUtil.line_text) }

--- a/led-commom/app/src/main/java/com/yjsoft/led/ui/fragment/SettingsFragment.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/ui/fragment/SettingsFragment.kt
@@ -1,6 +1,9 @@
 package com.yjsoft.led.ui.fragment
 
 import android.content.Intent
+import android.widget.EditText
+import androidx.appcompat.app.AlertDialog
+import com.yjsoft.led.util.SettingsUtils
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -27,6 +30,19 @@ class SettingsFragment : Fragment() {
         }
         binding.tvBle.setOnClickListener {
             startActivity(Intent(requireContext(), BleActivity::class.java))
+        }
+
+        binding.btnStartMessage.setOnClickListener {
+            val edit = EditText(requireContext())
+            edit.setText(SettingsUtils.getStartMessage(requireContext()))
+            AlertDialog.Builder(requireContext())
+                .setTitle(R.string.update_start_message)
+                .setView(edit)
+                .setPositiveButton(android.R.string.ok) { _, _ ->
+                    SettingsUtils.setStartMessage(requireContext(), edit.text.toString())
+                }
+                .setNegativeButton(android.R.string.cancel, null)
+                .show()
         }
     }
 

--- a/led-commom/app/src/main/java/com/yjsoft/led/util/SettingsUtils.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/util/SettingsUtils.kt
@@ -1,0 +1,20 @@
+package com.yjsoft.led.util
+
+import android.content.Context
+import com.yjsoft.led.R
+
+object SettingsUtils {
+    private const val PREFS_NAME = "settings"
+    private const val KEY_START_MESSAGE = "start_message"
+
+    fun getStartMessage(context: Context): String {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return prefs.getString(KEY_START_MESSAGE, context.getString(R.string.start_message))
+            ?: context.getString(R.string.start_message)
+    }
+
+    fun setStartMessage(context: Context, message: String) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit().putString(KEY_START_MESSAGE, message).apply()
+    }
+}

--- a/led-commom/app/src/main/java/com/yjsoft/led/util/ShowCmdUtil.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/util/ShowCmdUtil.kt
@@ -1,9 +1,13 @@
 package com.yjsoft.led.util
 
+import android.content.Context
 import com.yjsoft.core.utils.YJUtils
+import com.yjsoft.led.util.SettingsUtils
 
 object ShowCmdUtil {
-    val text = "{\"id_dev\":\"${YJUtils.dev_id}\",\"pkts_program\":{\"id_pro\":1,\"list_region\":[{\"info_pos\":{\"h\":64,\"w\":64,\"x\":0,\"y\":0},\"list_item\":[{\"align_horizontal\":\"left\",\"align_vertical\":\"top\",\"color\":255,\"data_save\":0,\"font\":\"/storage/emulated/0/Android/data/com.yjsoft.led/cache/Led/.font/NanumS.ttf\",\"info_animate\":{\"model_normal\":1,\"speed\":10,\"time_stay\":3},\"info_border\":{\"fixed_value\":0,\"type\":\"fixed\"},\"rotate\":0,\"size\":16,\"text\":\"测试\",\"type_item\":\"text_pic\"}]}],\"property_pro\":{\"gray\":4,\"height\":64,\"send_gif_src\":1,\"type_bg\":0,\"type_color\":3,\"type_pro\":0,\"width\":64}},\"sno\":\"${YJUtils.sno}\"}"
+    fun startText(context: Context): String {
+        return textMessage(SettingsUtils.getStartMessage(context))
+    }
 
     val one_text = "{\"id_dev\":\"${YJUtils.dev_id}\",\"pkts_program\":{\"id_pro\":2,\"list_region\":[{\"info_pos\":{\"h\":64,\"w\":64,\"x\":0,\"y\":0},\"list_item\":[{\"align_horizontal\":\"left\",\"align_vertical\":\"top\",\"color\":255,\"data_save\":0,\"font\":\"/storage/emulated/0/Android/data/com.yjsoft.led/cache/Led/.font/NanumS.ttf\",\"info_animate\":{\"model_normal\":1,\"speed\":10,\"time_stay\":3},\"info_border\":{\"fixed_value\":0,\"type\":\"fixed\"},\"list_text\":[{\"color\":16711935,\"text\":\"h\"},{\"color\":65535,\"text\":\"e\"},{\"color\":65280,\"text\":\"l\"},{\"color\":16711680,\"text\":\"l\"},{\"color\":65535,\"text\":\"o\"}],\"rotate\":0,\"size\":16,\"type_item\":\"text_pic\"}]}],\"property_pro\":{\"gray\":4,\"height\":64,\"send_gif_src\":1,\"type_bg\":0,\"type_color\":3,\"type_pro\":0,\"width\":64}},\"sno\":\"${YJUtils.sno}\"}"
     val two_text = "{\"id_dev\":\"${YJUtils.dev_id}\",\"pkts_program\":{\"id_pro\":3,\"list_region\":[{\"info_pos\":{\"h\":64,\"w\":64,\"x\":0,\"y\":0},\"list_item\":[{\"align_horizontal\":\"left\",\"align_vertical\":\"top\",\"color\":255,\"data_save\":0,\"font\":\"/storage/emulated/0/Android/data/com.yjsoft.led/cache/Led/.font/NanumS.ttf\",\"info_animate\":{\"model_normal\":1,\"speed\":10,\"time_stay\":3},\"info_border\":{\"fixed_value\":0,\"type\":\"fixed\"},\"list_text\":[{\"color\":16711935,\"text\":\"he\"},{\"color\":16776960,\"text\":\"ll\"},{\"color\":65535,\"text\":\"o\"}],\"rotate\":0,\"size\":16,\"type_item\":\"text_pic\"}]}],\"property_pro\":{\"gray\":4,\"height\":64,\"send_gif_src\":1,\"type_bg\":0,\"type_color\":3,\"type_pro\":0,\"width\":64}},\"sno\":\"${YJUtils.sno}\"}"

--- a/led-commom/app/src/main/res/layout/fragment_settings.xml
+++ b/led-commom/app/src/main/res/layout/fragment_settings.xml
@@ -20,4 +20,11 @@
         android:layout_height="wrap_content"
         android:text="블루투스 장치"
         tools:ignore="MissingConstraints" />
+
+    <Button
+        android:id="@+id/btn_start_message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/update_start_message"
+        tools:ignore="MissingConstraints" />
 </LinearLayout>

--- a/led-commom/app/src/main/res/values/strings.xml
+++ b/led-commom/app/src/main/res/values/strings.xml
@@ -10,6 +10,12 @@
     <string name="text_slot3">좋은하루 되세요!</string>
     <string name="text_slot4">오늘도 행복하세요!</string>
 
+    <!-- Default message sent when selecting the start text option -->
+    <string name="start_message">Welcome</string>
+
+    <!-- Button label used in settings to change the start message -->
+    <string name="update_start_message">Update Start Message</string>
+
     <style name="world_text">"{\"id_dev\":\"620312017C\",\"pkts_program\":{\"id_pro\":1,\"list_region\":[{\"info_pos\":{\"h\":64,\"w\":64,\"x\":0,\"y\":0},\"list_item\":[{\"align_horizontal\":\"left\",\"align_vertical\":\"top\",\"color\":255,\"data_save\":0,\"font\":\"/storage/emulated/0/Android/data/com.yj.led/cache/Led/.font/NanumS.ttf\",\"info_animate\":{\"model_normal\":1,\"speed\":10,\"time_stay\":3},\"info_border\":{\"fixed_value\":0,\"type\":\"fixed\"},\"rotate\":0,\"size\":16,\"text\":\"测试文字\",\"type_item\":\"text_pic\"}]}],\"property_pro\":{\"gray\":4,\"height\":64,\"send_gif_src\":1,\"type_bg\":0,\"type_color\":3,\"type_pro\":0,\"width\":64}},\"sno\":\"4294901763\"}"</style>
 
     <string name="tab_operation">조작</string>


### PR DESCRIPTION
## Summary
- add `start_message` and `update_start_message` strings
- add button in settings screen to change start message
- implement `SettingsUtils` for persisted settings
- compute LED start text via `ShowCmdUtil.startText`
- use configurable text in BLE and WiFi activities

## Testing
- `./gradlew test` *(fails: `/usr/bin/env: ‘sh\r’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_685bd51447b88329bfcffe63b19606a6