### PR TITLE
Add selectable image buttons

### DIFF
--- a/led-commom/app/src/main/java/com/yjsoft/led/ui/fragment/OperationFragment.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/ui/fragment/OperationFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import android.graphics.BitmapFactory
 import android.widget.Toast
 import android.widget.SeekBar
+import android.widget.ImageButton
 import com.yjsoft.core.YJDeviceManager
 import com.yjsoft.core.utils.YJZipUtils
 import com.yjsoft.led.util.ShowCmdUtil
@@ -17,6 +18,7 @@ import com.yjsoft.led.databinding.FragmentOperationBinding
 class OperationFragment : Fragment() {
     private var _binding: FragmentOperationBinding? = null
     private val binding get() = _binding!!
+    private var selectedButton: ImageButton? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         _binding = FragmentOperationBinding.inflate(inflater, container, false)
@@ -25,16 +27,30 @@ class OperationFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        // Default text buttons are hidden for now
+        val buttons = listOf(
+            binding.btnImage1,
+            binding.btnImage2,
+            binding.btnImage3,
+            binding.btnImage4,
+            binding.btnImage5,
+            binding.btnImage6,
+            binding.btnImage7,
+            binding.btnImage8
+        )
 
-        binding.btnImage1.setOnClickListener { sendImage("images/img1.jpg") }
-        binding.btnImage2.setOnClickListener { sendImage("images/img2.jpg") }
-        binding.btnImage3.setOnClickListener { sendImage("images/img3.jpg") }
-        binding.btnImage4.setOnClickListener { sendImage("images/img4.jpg") }
-        binding.btnImage5.setOnClickListener { sendImage("images/img5.jpg") }
-        binding.btnImage6.setOnClickListener { sendImage("images/img6.jpg") }
-        binding.btnImage7.setOnClickListener { sendImage("images/img7.jpg") }
-        binding.btnImage8.setOnClickListener { sendImage("images/img8.jpg") }
+        buttons.forEachIndexed { index, button ->
+            try {
+                requireContext().assets.open("images/img${index + 1}.jpg").use { stream ->
+                    val bitmap = BitmapFactory.decodeStream(stream)
+                    button.setImageBitmap(bitmap)
+                }
+            } catch (_: Exception) {
+            }
+            button.setOnClickListener {
+                selectButton(button)
+                sendImage("images/img${index + 1}.jpg")
+            }
+        }
 
         binding.seekbar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
@@ -52,6 +68,12 @@ class OperationFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun selectButton(button: ImageButton) {
+        selectedButton?.isSelected = false
+        selectedButton = button
+        selectedButton?.isSelected = true
     }
 
     private fun showToast(text: String) {

--- a/led-commom/app/src/main/res/drawable/image_button_selected.xml
+++ b/led-commom/app/src/main/res/drawable/image_button_selected.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/transparent" />
+    <stroke android:width="2dp" android:color="@color/colorAccent" />
+    <corners android:radius="4dp" />
+</shape>

--- a/led-commom/app/src/main/res/drawable/image_button_selector.xml
+++ b/led-commom/app/src/main/res/drawable/image_button_selector.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/image_button_selected" android:state_selected="true" />
+    <item android:drawable="@drawable/image_button_selected" android:state_pressed="true" />
+    <item android:drawable="@drawable/image_button_unselected" />
+</selector>

--- a/led-commom/app/src/main/res/drawable/image_button_unselected.xml
+++ b/led-commom/app/src/main/res/drawable/image_button_unselected.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/transparent" />
+    <stroke android:width="2dp" android:color="@android:color/transparent" />
+    <corners android:radius="4dp" />
+</shape>

--- a/led-commom/app/src/main/res/layout/fragment_operation.xml
+++ b/led-commom/app/src/main/res/layout/fragment_operation.xml
@@ -30,14 +30,62 @@
             android:id="@+id/btn_text4"
             android:text="@string/text_slot4" />
         -->
-        <Button android:id="@+id/btn_image1" android:text="image1" />
-        <Button android:id="@+id/btn_image2" android:text="image2" />
-        <Button android:id="@+id/btn_image3" android:text="image3" />
-        <Button android:id="@+id/btn_image4" android:text="image4" />
-        <Button android:id="@+id/btn_image5" android:text="image5" />
-        <Button android:id="@+id/btn_image6" android:text="image6" />
-        <Button android:id="@+id/btn_image7" android:text="image7" />
-        <Button android:id="@+id/btn_image8" android:text="image8" />
+        <ImageButton
+            android:id="@+id/btn_image1"
+            android:layout_width="0dp"
+            android:layout_height="64dp"
+            android:layout_columnWeight="1"
+            android:background="@drawable/image_button_selector"
+            android:scaleType="centerCrop" />
+        <ImageButton
+            android:id="@+id/btn_image2"
+            android:layout_width="0dp"
+            android:layout_height="64dp"
+            android:layout_columnWeight="1"
+            android:background="@drawable/image_button_selector"
+            android:scaleType="centerCrop" />
+        <ImageButton
+            android:id="@+id/btn_image3"
+            android:layout_width="0dp"
+            android:layout_height="64dp"
+            android:layout_columnWeight="1"
+            android:background="@drawable/image_button_selector"
+            android:scaleType="centerCrop" />
+        <ImageButton
+            android:id="@+id/btn_image4"
+            android:layout_width="0dp"
+            android:layout_height="64dp"
+            android:layout_columnWeight="1"
+            android:background="@drawable/image_button_selector"
+            android:scaleType="centerCrop" />
+        <ImageButton
+            android:id="@+id/btn_image5"
+            android:layout_width="0dp"
+            android:layout_height="64dp"
+            android:layout_columnWeight="1"
+            android:background="@drawable/image_button_selector"
+            android:scaleType="centerCrop" />
+        <ImageButton
+            android:id="@+id/btn_image6"
+            android:layout_width="0dp"
+            android:layout_height="64dp"
+            android:layout_columnWeight="1"
+            android:background="@drawable/image_button_selector"
+            android:scaleType="centerCrop" />
+        <ImageButton
+            android:id="@+id/btn_image7"
+            android:layout_width="0dp"
+            android:layout_height="64dp"
+            android:layout_columnWeight="1"
+            android:background="@drawable/image_button_selector"
+            android:scaleType="centerCrop" />
+        <ImageButton
+            android:id="@+id/btn_image8"
+            android:layout_width="0dp"
+            android:layout_height="64dp"
+            android:layout_columnWeight="1"
+            android:background="@drawable/image_button_selector"
+            android:scaleType="centerCrop" />
     </GridLayout>
 
     <SeekBar


### PR DESCRIPTION
## Summary
- update `fragment_operation.xml` buttons to `ImageButton`
- highlight currently selected image with a selector drawable
- update `OperationFragment` to load images and track selection

## Testing
- `bash led-commom/gradlew -p led-commom assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685bd70b10608329b9b098e367275cb9