### PR TITLE
Update operation fragment styles

### DIFF
--- a/led-commom/app/src/main/res/drawable/image_button_selected.xml
+++ b/led-commom/app/src/main/res/drawable/image_button_selected.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="@android:color/transparent" />
-    <stroke android:width="2dp" android:color="@color/colorAccent" />
-    <corners android:radius="4dp" />
+    <stroke android:width="3dp" android:color="@android:color/yellow" />
+    <corners android:radius="7dp" />
 </shape>

--- a/led-commom/app/src/main/res/drawable/image_button_unselected.xml
+++ b/led-commom/app/src/main/res/drawable/image_button_unselected.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="@android:color/transparent" />
-    <stroke android:width="2dp" android:color="@android:color/transparent" />
-    <corners android:radius="4dp" />
+    <stroke android:width="3dp" android:color="@android:color/transparent" />
+    <corners android:radius="7dp" />
 </shape>

--- a/led-commom/app/src/main/res/layout/fragment_operation.xml
+++ b/led-commom/app/src/main/res/layout/fragment_operation.xml
@@ -15,7 +15,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:columnCount="4"
-        android:padding="8dp">
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:paddingStart="15dp"
+        android:paddingEnd="15dp">
         <!--
         <Button
             android:id="@+id/btn_text1"
@@ -32,60 +35,68 @@
         -->
         <ImageButton
             android:id="@+id/btn_image1"
-            android:layout_width="0dp"
+            android:layout_width="64dp"
             android:layout_height="64dp"
-            android:layout_columnWeight="1"
+            android:layout_margin="8dp"
             android:background="@drawable/image_button_selector"
-            android:scaleType="centerCrop" />
+            android:scaleType="centerCrop"
+            android:elevation="2dp" />
         <ImageButton
             android:id="@+id/btn_image2"
-            android:layout_width="0dp"
+            android:layout_width="64dp"
             android:layout_height="64dp"
-            android:layout_columnWeight="1"
+            android:layout_margin="8dp"
             android:background="@drawable/image_button_selector"
-            android:scaleType="centerCrop" />
+            android:scaleType="centerCrop"
+            android:elevation="2dp" />
         <ImageButton
             android:id="@+id/btn_image3"
-            android:layout_width="0dp"
+            android:layout_width="64dp"
             android:layout_height="64dp"
-            android:layout_columnWeight="1"
+            android:layout_margin="8dp"
             android:background="@drawable/image_button_selector"
-            android:scaleType="centerCrop" />
+            android:scaleType="centerCrop"
+            android:elevation="2dp" />
         <ImageButton
             android:id="@+id/btn_image4"
-            android:layout_width="0dp"
+            android:layout_width="64dp"
             android:layout_height="64dp"
-            android:layout_columnWeight="1"
+            android:layout_margin="8dp"
             android:background="@drawable/image_button_selector"
-            android:scaleType="centerCrop" />
+            android:scaleType="centerCrop"
+            android:elevation="2dp" />
         <ImageButton
             android:id="@+id/btn_image5"
-            android:layout_width="0dp"
+            android:layout_width="64dp"
             android:layout_height="64dp"
-            android:layout_columnWeight="1"
+            android:layout_margin="8dp"
             android:background="@drawable/image_button_selector"
-            android:scaleType="centerCrop" />
+            android:scaleType="centerCrop"
+            android:elevation="2dp" />
         <ImageButton
             android:id="@+id/btn_image6"
-            android:layout_width="0dp"
+            android:layout_width="64dp"
             android:layout_height="64dp"
-            android:layout_columnWeight="1"
+            android:layout_margin="8dp"
             android:background="@drawable/image_button_selector"
-            android:scaleType="centerCrop" />
+            android:scaleType="centerCrop"
+            android:elevation="2dp" />
         <ImageButton
             android:id="@+id/btn_image7"
-            android:layout_width="0dp"
+            android:layout_width="64dp"
             android:layout_height="64dp"
-            android:layout_columnWeight="1"
+            android:layout_margin="8dp"
             android:background="@drawable/image_button_selector"
-            android:scaleType="centerCrop" />
+            android:scaleType="centerCrop"
+            android:elevation="2dp" />
         <ImageButton
             android:id="@+id/btn_image8"
-            android:layout_width="0dp"
+            android:layout_width="64dp"
             android:layout_height="64dp"
-            android:layout_columnWeight="1"
+            android:layout_margin="8dp"
             android:background="@drawable/image_button_selector"
-            android:scaleType="centerCrop" />
+            android:scaleType="centerCrop"
+            android:elevation="2dp" />
     </GridLayout>
 
     <SeekBar


### PR DESCRIPTION
## Summary
- adjust padding and margin for image grid
- make image buttons square with elevation
- highlight selected image with yellow outline

## Testing
- `bash gradlew --version` *(fails: command not found due to line endings)*

------
https://chatgpt.com/codex/tasks/task_e_685bd8ec93e48329ad4956229f9e28d5