### PR TITLE
Enable GIF image support for buttons

### DIFF
--- a/led-commom/app/src/main/java/com/yjsoft/led/ui/BleActivity.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/ui/BleActivity.kt
@@ -157,7 +157,8 @@ class BleActivity : AppCompatActivity(), YJCallBack {
 
     private fun gifByteArray(): ByteArray {
         return try {
-            assets.open("images/img1.jpg").use { stream ->
+            val path = if (assetExists("images/img1.gif")) "images/img1.gif" else "images/img1.jpg"
+            assets.open(path).use { stream ->
                 val byteArrayOutputStream = ByteArrayOutputStream()
                 var len: Int
                 val b = ByteArray(1024)
@@ -244,6 +245,15 @@ class BleActivity : AppCompatActivity(), YJCallBack {
             progressDialog?.dismiss()
         } else {
             progressBinding?.tvStatus?.text = "${currentSendDesc} 전송 중...${progress}%"
+        }
+    }
+
+    private fun assetExists(path: String): Boolean {
+        return try {
+            assets.open(path).close()
+            true
+        } catch (_: Exception) {
+            false
         }
     }
 

--- a/led-commom/app/src/main/java/com/yjsoft/led/ui/WifiActivity.kt
+++ b/led-commom/app/src/main/java/com/yjsoft/led/ui/WifiActivity.kt
@@ -169,7 +169,8 @@ class WifiActivity : AppCompatActivity(), YJCallBack {
 
     private fun gifByteArray(): ByteArray {
         return try {
-            assets.open("images/img1.jpg").use { stream ->
+            val path = if (assetExists("images/img1.gif")) "images/img1.gif" else "images/img1.jpg"
+            assets.open(path).use { stream ->
                 val byteArrayOutputStream = ByteArrayOutputStream()
                 var len: Int
                 val b = ByteArray(1024)
@@ -344,5 +345,14 @@ class WifiActivity : AppCompatActivity(), YJCallBack {
         val toast = Toast.makeText(this,text,Toast.LENGTH_SHORT)
         toast.setGravity(Gravity.CENTER,0,0)
         toast.show()
+    }
+
+    private fun assetExists(path: String): Boolean {
+        return try {
+            assets.open(path).close()
+            true
+        } catch (_: Exception) {
+            false
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow OperationFragment buttons to detect and display `.gif` assets if present
- show preview of GIF images using first frame
- send GIF data in WifiActivity and BleActivity when gif assets are available
- add asset existence helpers in related activities

## Testing
- `./gradlew test` *(fails: Unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685be53ce3008329a24dfe2439db0d2c