### PR TITLE
Fix aar dependency configuration

### DIFF
--- a/led-commom/app/build.gradle
+++ b/led-commom/app/build.gradle
@@ -2,6 +2,9 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
+repositories {
+    flatDir { dirs 'libs' }
+}
 
 android {
     namespace "com.yjsoft.led"
@@ -63,7 +66,7 @@ dependencies {
 
 //    implementation project(":core")
     // Local AAR dependency
-    implementation files('libs/core-release.aar')
+    implementation(name: 'core-release', ext: 'aar')
 //    implementation 'com.google.code.gson:gson:2.8.6'
 //    implementation files('libs/yj_core.jar')
 }


### PR DESCRIPTION
## Summary
- configure a flat directory repository in the `app` module
- include `core-release.aar` using the correct Gradle syntax

## Testing
- `./gradlew test` *(fails: Unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_685c192ac0d08329be6acb6e3285d11a